### PR TITLE
Use HTTPS over HTTP

### DIFF
--- a/scripts/bungie-data-helper.coffee
+++ b/scripts/bungie-data-helper.coffee
@@ -20,7 +20,7 @@ class DataHelper
       console.log(Object.keys(response.definitions.damageTypes).length)
       console.log("damageType empty for #{itemDefs.itemName}")
 
-    prefix = 'http://www.bungie.net'
+    prefix = 'https://www.bungie.net'
     iconSuffix = itemDefs.icon
     itemSuffix = '/en/Armory/Detail?item='+hash
 


### PR DESCRIPTION
If behind a firewall, HTTPS seems to go through whereas HTTP might be blocked (my case). Since there's no longer any downsides to using HTTPS, I propose the bot uses the https link and this PR implements that.
