### PR TITLE
Adding weapon stats to the output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store*
 .hubot_history
 .env
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .hubot_history
 .env
 .vscode
+scripts/*.js
+scripts/*.map

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "q": "^1.4.1",
     "request": "^2.64.0"
   },
+  "devDependencies": {
+    "jshint": "*"
+  },
   "engines": {
     "node": "0.10.x"
   }

--- a/scripts/bungie-data-helper.coffee
+++ b/scripts/bungie-data-helper.coffee
@@ -1,13 +1,47 @@
 request = require('request')
 
 class DataHelper
+  statHashes = 
+    "2391494160": "Light" 
+    "2523465841": "Velocity" 
+    "2715839340": "Recoil direction" 
+    "2762071195": "Efficiency" 
+    "2837207746": "Speed" 
+    "2961396640": "Charge Rate" 
+    "2996146975": "Agility" 
+    "3017642079": "Boost" 
+    "3555269338": "Optics" 
+    "3597844532": "Precision Damage" 
+    "3614673599": "Blast Radius" 
+    "3871231066": "Magazine" 
+    "3897883278": "Defense" 
+    "3907551967": "Move speed" 
+    "3988418950": "ADS Speed" 
+    "4043523819": "Impact" 
+    "4188031367": "Reload" 
+    "4244567218": "Strength" 
+    "4284893193": "Rate of Fire" 
+    "144602215": "Intellect" 
+    "155624089": "Stability" 
+    "209426660": "Defense" 
+    "360359141": "Durability" 
+    "368428387": "Attack" 
+    "392767087": "Armor" 
+    "925767036": "Energy" 
+    "943549884": "Equip Speed" 
+    "1240592695": "Range" 
+    "1345609583": "Aim assistance" 
+    "1501155019": "Speed" 
+    "1735777505": "Discipline" 
+    "1931675084": "Inventory Size" 
+    "1943323491": "Recovery" 
+
   'serializeFromApi': (response) ->
     damageColor =
       Kinetic: '#d9d9d9'
       Arc: '#80b3ff'
       Solar: '#e68a00'
       Void: '#400080'
-
     item = response.data.item
     hash = item.itemHash
     itemDefs = response.definitions.items[hash]
@@ -33,12 +67,13 @@ class DataHelper
     nodes: response.data.talentNodes
     nodeDefs: response.definitions.talentGrids[item.talentGridHash].nodes
     damageType: damageTypeName
+    stats: item.stats #TODO: maybe extract the stats here
 
   'parseItemAttachment': (item) ->
     name = "#{item.itemName}"
     name+= " [#{item.damageType}]" unless item.damageType is "Kinetic"
     filtered = @filterNodes(item.nodes, item.nodeDefs)
-    textHash = @buildText(filtered, item.nodeDefs)
+    textHash = @buildText(filtered, item.nodeDefs, item)
     formattedText = for column, string of textHash
       # removes trailing " | " from each line
       string.slice(0, -3)
@@ -73,7 +108,7 @@ class DataHelper
       column++
     return orderedNodes
 
-  'buildText': (nodes, nodeDefs) ->
+  'buildText': (nodes, nodeDefs, item) ->
     getName = (node) ->
       step = nodeDefs[node.nodeIndex].steps[node.stepIndex]
       return step.nodeStepName
@@ -89,6 +124,11 @@ class DataHelper
       text[column]+= name + " | "
 
     setText node for node in nodes
-    return text
+    stats = []
+    for stat in item.stats
+      if stat.statHash of statHashes
+        stats.push "#{statHashes[stat.statHash]} : #{stat.value}"
+    text['Stats'] = stats.join ', '
+    return text 
 
 module.exports = DataHelper

--- a/scripts/bungie-data-helper.coffee
+++ b/scripts/bungie-data-helper.coffee
@@ -53,6 +53,10 @@ class DataHelper
       damageTypeName = 'Kinetic'
       console.log(Object.keys(response.definitions.damageTypes).length)
       console.log("damageType empty for #{itemDefs.itemName}")
+    stats = {}
+    for stat in item.stats
+      if stat.statHash of statHashes
+        stats[statHashes[stat.statHash]] = stat.value
 
     prefix = 'http://www.bungie.net'
     iconSuffix = itemDefs.icon
@@ -67,7 +71,7 @@ class DataHelper
     nodes: response.data.talentNodes
     nodeDefs: response.definitions.talentGrids[item.talentGridHash].nodes
     damageType: damageTypeName
-    stats: item.stats #TODO: maybe extract the stats here
+    stats: stats
 
   'parseItemAttachment': (item) ->
     name = "#{item.itemName}"
@@ -122,9 +126,8 @@ class DataHelper
 
     setText node for node in nodes
     stats = []
-    for stat in item.stats
-      if stat.statHash of statHashes
-        stats.push "#{statHashes[stat.statHash]} : #{stat.value}"
+    for statName, statValue of item.stats
+        stats.push "#{statName} : #{statValue}"
     text['Stats'] = stats.join ', '
     return text 
 

--- a/scripts/bungie-data-helper.coffee
+++ b/scripts/bungie-data-helper.coffee
@@ -127,7 +127,7 @@ class DataHelper
     setText node for node in nodes
     stats = []
     for statName, statValue of item.stats
-        stats.push "#{statName} : #{statValue}"
+        stats.push "#{statName}: #{statValue}"
     text['Stats'] = stats.join ', '
     return text 
 

--- a/scripts/bungie-data-helper.coffee
+++ b/scripts/bungie-data-helper.coffee
@@ -74,15 +74,12 @@ class DataHelper
     name+= " [#{item.damageType}]" unless item.damageType is "Kinetic"
     filtered = @filterNodes(item.nodes, item.nodeDefs)
     textHash = @buildText(filtered, item.nodeDefs, item)
-    formattedText = for column, string of textHash
-      # removes trailing " | " from each line
-      string.slice(0, -3)
 
     fallback: item.itemDescription
     title: name
     title_link: item.itemLink
     color: item.color
-    text: formattedText.join('\n')
+    text: (string for column, string of textHash).join('\n')
     mrkdwn_in: ["text"]
     thumb_url: item.iconLink
 
@@ -121,7 +118,7 @@ class DataHelper
       if node.isActivated
         name = "*#{step.nodeStepName}*"
       text[column] = "" unless text[column]
-      text[column]+= name + " | "
+      text[column] += (if text[column] then '|' else '') + name
 
     setText node for node in nodes
     stats = []

--- a/scripts/bungie-data-helper.coffee
+++ b/scripts/bungie-data-helper.coffee
@@ -78,6 +78,7 @@ class DataHelper
     name+= " [#{item.damageType}]" unless item.damageType is "Kinetic"
     filtered = @filterNodes(item.nodes, item.nodeDefs)
     textHash = @buildText(filtered, item.nodeDefs, item)
+    footerText = @buildFooter(item)
 
     fallback: item.itemDescription
     title: name
@@ -85,6 +86,7 @@ class DataHelper
     color: item.color
     text: (string for column, string of textHash).join('\n')
     mrkdwn_in: ["text"]
+    footer: footerText
     thumb_url: item.iconLink
 
   # removes invalid nodes, orders according to column attribute
@@ -125,10 +127,13 @@ class DataHelper
       text[column] += (if text[column] then ' | ' else '') + name
 
     setText node for node in nodes
+    return text 
+
+  # stats go in the footer
+  'buildFooter': (item) ->
     stats = []
     for statName, statValue of item.stats
         stats.push "#{statName}: #{statValue}"
-    text['Stats'] = stats.join ', '
-    return text 
+    stats.join ', '
 
 module.exports = DataHelper

--- a/scripts/bungie-data-helper.coffee
+++ b/scripts/bungie-data-helper.coffee
@@ -118,7 +118,7 @@ class DataHelper
       if node.isActivated
         name = "*#{step.nodeStepName}*"
       text[column] = "" unless text[column]
-      text[column] += (if text[column] then '|' else '') + name
+      text[column] += (if text[column] then ' | ' else '') + name
 
     setText node for node in nodes
     stats = []

--- a/scripts/bungie.coffee
+++ b/scripts/bungie.coffee
@@ -240,7 +240,7 @@ makeRequest = (bot, endpoint, callback, params) ->
   queryParams = if params then '?'+params else ''
   url = baseUrl+endpoint+trailing+queryParams
 
-  # console.log("making request: #{url}")
+  console.log("making request: #{url}")
 
   bot.http(url)
     .header('X-API-Key', BUNGIE_API_KEY)

--- a/scripts/bungie.coffee
+++ b/scripts/bungie.coffee
@@ -69,7 +69,8 @@ module.exports = (robot) ->
             payload =
               message: res.message
               attachments: parsedItem
-
+            
+            console.log payload
             robot.emit 'slack-attachment', payload
 
   robot.respond /help/i, (res) ->
@@ -239,7 +240,7 @@ makeRequest = (bot, endpoint, callback, params) ->
   queryParams = if params then '?'+params else ''
   url = baseUrl+endpoint+trailing+queryParams
 
-  console.log("making request: #{url}")
+  # console.log("making request: #{url}")
 
   bot.http(url)
     .header('X-API-Key', BUNGIE_API_KEY)


### PR DESCRIPTION
The perks tell only part of the story - the weapon stats are very important in the ability to identify weapon classes and compare weapons of the same archetype.

This patch displays the stats available under `item.stats` for the weapon using the stats names from the API manifest.
