### PR TITLE
FIX: Weapon stats accounting for perks

### DIFF
--- a/scripts/bungie-constants.coffee
+++ b/scripts/bungie-constants.coffee
@@ -43,5 +43,6 @@ module.exports =
       "1735777505": "Discipline" 
       "1931675084": "Inventory Size" 
       "1943323491": "Recovery" 
+    EXTENDED_WEAPON_STATS: [ "1345609583", "943549884" ]
     DEFAULT_SETTINGS:
       SLOT_DISPLAY: "armor,weapons"

--- a/scripts/bungie-data-helper.coffee
+++ b/scripts/bungie-data-helper.coffee
@@ -21,10 +21,16 @@ class DataHelper
       console.log("damageType empty for #{itemDefs.itemName}")
     stats = {}
     # for stat in item.stats
-    itemStats = if item.damageType == 0 then item.stats else response.definitions.items[hash].stats
+    itemStats = item.stats
+
+    if item.damageType isnt 0
+      # if it's a weapon, we'll extend base stats with those from definitions
+      itemStatHashes = ( "#{x.statHash}" for x in item.stats )
+      for h, s of response.definitions.items[hash].stats when h not in itemStatHashes
+        itemStats.push s
+  
     statHashes = constants.STAT_HASHES
-    for statHash, stat of itemStats
-      if stat.statHash of statHashes
+    for stat in itemStats when stat.statHash of statHashes
         stats[statHashes[stat.statHash]] = stat.value
 
     prefix = 'https://www.bungie.net'

--- a/scripts/bungie-data-helper.coffee
+++ b/scripts/bungie-data-helper.coffee
@@ -24,9 +24,16 @@ class DataHelper
     itemStats = item.stats
 
     if item.damageType isnt 0
-      # if it's a weapon, we'll extend base stats with those from definitions
-      itemStatHashes = ( "#{x.statHash}" for x in item.stats )
-      for h, s of response.definitions.items[hash].stats when h not in itemStatHashes
+      # if it's a weapon, we'll extend base stats with 
+
+      # to expand using all the hidden stats, use the code below
+      # itemStatHashes = ( "#{x.statHash}" for x in item.stats )
+      # for h, s of response.definitions.items[hash].stats when h not in itemStatHashes
+      #   itemStats.push s
+
+      # to expand using a smaller list, match against EXTENDED_WEAPON_STATS
+      for extHash in constants.EXTENDED_WEAPON_STATS
+        s = response.definitions.items[hash].stats[extHash]
         itemStats.push s
   
     statHashes = constants.STAT_HASHES


### PR DESCRIPTION
With deep apologies... 
This fixes an issue where the selected perks were not accounting for when displaying the weapon stats.